### PR TITLE
Use proxy URL on web

### DIFF
--- a/build.html
+++ b/build.html
@@ -22,11 +22,11 @@
         transport: function (options) {
           options.auth.auth_token = userToken;
 
-          // Proxy Sentry errors on native platforms because of a Cordova bug
-          // https://github.com/getsentry/sentry-javascript/issues/628
-          if (Fliplet.Env.is('native')) {
-            options.url = Fliplet.Env.get('apiUrl') + 'v1/raven/' + options.url;
-          }
+          /* Proxy errors for two reasons
+           * 1. Bug on Cordova https://github.com/getsentry/sentry-javascript/issues/628
+           * 2. We want to rate limit clients sending errors
+           */
+          options.url = Fliplet.Env.get('apiUrl') + 'v1/raven/' + options.url;
 
           options.data.appId = Fliplet.Env.get('appId');
           this.ea(options);

--- a/js/build.js
+++ b/js/build.js
@@ -1,4 +1,0 @@
-(function () {
-  // TODO:
-  // Get script from html to thi file once we can include assets on the head scripts
-})();

--- a/widget.json
+++ b/widget.json
@@ -22,8 +22,6 @@
       "fliplet-core",
       "!ravenjs"
     ],
-    "assets": [
-      "js/build.js"
-    ]
+    "assets": []
   }
 }


### PR DESCRIPTION
- Use Proxy when reporting from all platforms (not just mobile)
- Cleanup for unused files

---

ref https://github.com/Fliplet/fliplet-studio/issues/4545